### PR TITLE
feat: mount the entire `.ddev/php` directory, fixes #6

### DIFF
--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -30,6 +30,7 @@ services:
       com.ddev.approot: ${DDEV_APPROOT}
     environment:
       - SERVER_NAME=:8000
+      - PHP_INI_SCAN_DIR=:/usr/local/etc/php/ddev.conf.d
       - VIRTUAL_HOST=${DDEV_HOSTNAME}
       - HTTP_EXPOSE=80:8000
       - HTTPS_EXPOSE=443:8000
@@ -37,7 +38,7 @@ services:
     volumes:
       - "../:/var/www/html"
       - "./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile"
-      - "./php/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+      - "./php:/usr/local/etc/php/ddev.conf.d"
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
     # Two lines below are for Xdebug on Linux, see README.md for details


### PR DESCRIPTION
## The Issue

- Fixes #6

## How This PR Solves The Issue

Uses `PHP_INI_SCAN_DIR`, see https://frankenphp.dev/docs/config/#php-config

## Manual Testing Instructions

```bash
touch .ddev/php/custom.ini
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/9/head
ddev restart

# see custom.ini in the output
ddev php --ini
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
