### PR TITLE
refactor: move xdebug.ini to docker-compose configs

### DIFF
--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -44,3 +44,18 @@ services:
     # Two lines below are for Xdebug on Linux, see README.md for details
     # extra_hosts:
     #   - "host.docker.internal:host-gateway"
+    configs:
+      - source: ddev-xdebug.ini
+        target: /usr/local/etc/php/conf.d/ddev-xdebug.ini
+        mode: "0444"
+
+configs:
+  ddev-xdebug.ini:
+    content: |
+      zend_extension=xdebug.so
+      xdebug.client_host=host.docker.internal
+      xdebug.discover_client_host=1
+      xdebug.client_port=9003
+      xdebug.mode=debug,develop
+      xdebug.start_with_request=yes
+      xdebug.max_nesting_level=1000

--- a/install.yaml
+++ b/install.yaml
@@ -4,7 +4,6 @@ project_files:
   - commands/frankenphp/php
   - docker-compose.frankenphp.yaml
   - frankenphp/Caddyfile
-  - php/docker-php-ext-xdebug.ini
 
 pre_install_actions:
   - |
@@ -14,5 +13,16 @@ pre_install_actions:
     echo "Run 'ddev config --webserver-type=generic' and repeat this command again."
     exit 1
     {{ end }}
+  - |
+    #ddev-description:Removing old files
+    file="${DDEV_APPROOT}/.ddev/php/docker-php-ext-xdebug.ini"
+    if [ -f "${file}" ]; then
+      if grep -q '#ddev-generated' "${file}"; then
+        rm -f "${file}"
+      else
+        echo "${file} needs to be removed but has been modified by the user. Please check it and remove it"
+        exit 2
+      fi
+    fi
 
 ddev_version_constraint: '>= v1.24.3'

--- a/php/docker-php-ext-xdebug.ini
+++ b/php/docker-php-ext-xdebug.ini
@@ -1,8 +1,0 @@
-#ddev-generated
-zend_extension=xdebug.so
-xdebug.client_host=host.docker.internal
-xdebug.discover_client_host=1
-xdebug.client_port=9003
-xdebug.mode=debug,develop
-xdebug.start_with_request=yes
-xdebug.max_nesting_level=1000


### PR DESCRIPTION
## The Issue

There is no apparent reason to have `.ddev/php/docker-php-ext-xdebug.ini` file.

## How This PR Solves The Issue

Moves it to docker-compose configs.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/11/head
ddev restart
ddev php --ini                                # should list /usr/local/etc/php/conf.d/ddev-xdebug.ini
ls -la .ddev/php/docker-php-ext-xdebug.ini    # should not be here
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
