### PR TITLE
feat: add FRANKENPHP_HOST_HTTP_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,23 @@ ddev stop && ddev debug rebuild -s frankenphp && ddev start
 
 ---
 
+To set a specific HTTP port for FrankenPHP on localhost:
+
+```bash
+ddev dotenv set .ddev/.env.frankenphp --frankenphp-host-http-port=8080
+ddev restart
+```
+
+Make sure to commit the `.ddev/.env.frankenphp` file to version control.
+
+---
+
 All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
 | `FRANKENPHP_DOCKER_IMAGE` | `--frankenphp-docker-image` | `dunglas/frankenphp:php8.3` |
+| `FRANKENPHP_HOST_HTTP_PORT` | `--frankenphp-host-http-port` | (random) |
 | `FRANKENPHP_PHP_EXTENSIONS` | `--frankenphp-php-extensions` | (not set) |
 
 ## Resources:

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -50,6 +50,9 @@ services:
       - HTTP_EXPOSE=80:80
       - HTTPS_EXPOSE=443:80
       - PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
+    # direct access without ddev-router
+    ports:
+      - "${FRANKENPHP_HOST_HTTP_PORT:-}:80"
     working_dir: /var/www/html
     volumes:
       - "../:/var/www/html"


### PR DESCRIPTION
## The Issue

FrankenPHP should be close to what we have in the `ddev-webserver`.

`ddev-webserver` has random HTTP and HTTPS ports exposed to localhost:

Specifically:

- `http://127.0.0.1:33051`
- `https://127.0.0.1:33052`

```
$ ddev describe                                                         
┌───────────────────────────────────────────────────────────────────────────────────────────────┐
│ Project: d11 ~/code/ddev-quickstarts/d11 https://d11.ddev.site                                │
│ Docker platform: linux-docker                                                                 │
│ Router: traefik                                                                               │
│ DDEV version: v1.24.7-78-g8b8b6be2b-dirty                                                     │
├──────────────┬──────┬────────────────────────────────────────────────────┬────────────────────┤
│ SERVICE      │ STAT │ URL/PORT                                           │ INFO               │
├──────────────┼──────┼────────────────────────────────────────────────────┼────────────────────┤
│ web          │ OK   │ https://d11.ddev.site                              │ drupal11 PHP 8.3   │
│              │      │ InDocker -> Host:                                  │ Server: nginx-fpm  │
│              │      │  - web:80 -> 127.0.0.1:33051                       │ Docroot: 'web'     │
│              │      │  - web:443 -> 127.0.0.1:33052                      │ Perf mode: none    │
│              │      │  - web:8025 -> 127.0.0.1:33053                     │ Node.js: 18        │
├──────────────┼──────┼────────────────────────────────────────────────────┼────────────────────┤
│ db           │ OK   │ InDocker -> Host:                                  │ mariadb:10.11      │
│              │      │  - db:3306 -> 127.0.0.1:33054                      │ User/Pass: 'db/db' │
│              │      │                                                    │ or 'root/root'     │
├──────────────┼──────┼────────────────────────────────────────────────────┼────────────────────┤
│ Mailpit      │      │ Mailpit: https://d11.ddev.site:8026                │                    │
│              │      │ Launch: ddev mailpit                               │                    │
├──────────────┼──────┼────────────────────────────────────────────────────┼────────────────────┤
│ Project URLs │      │ https://d11.ddev.site, https://127.0.0.1:33052,    │                    │
│              │      │ http://d11.ddev.site, http://127.0.0.1:33051       │                    │
└──────────────┴──────┴────────────────────────────────────────────────────┴────────────────────┘
```

## How This PR Solves The Issue

Adds support for direct HTTP port.

I tried to add direct HTTPS support, but it's tricky:

- https://frankenphp.dev/docs/known-issues/#using-https127001-with-docker

I'll leave HTTPS to another time.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev config --webserver-type=generic
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/26/head
ddev restart

# see a random HTTP port, like 127.0.0.1:33080 for frankenphp:80, open it
ddev describe

ddev dotenv set .ddev/.env.frankenphp --frankenphp-host-http-port=8080
ddev restart

# see 127.0.0.1:8080 for frankenphp:80
ddev describe

# open it
ddev launch http://127.0.0.1:8080
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
