### PR TITLE
feat: use socat as proxy for frankenphp in web container, fixes #13, fixes #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ After installation, make sure to commit the `.ddev` directory to version control
 ## Caveats
 
 - `ddev xdebug` and `ddev xhprof` are only designed to work in the `web` container, it won't work here.
-- `ddev launch` doesn't work. Open the website URL directly in your browser.
 
 ## Advanced Customization
 
@@ -90,22 +89,9 @@ services:
 
 ---
 
-To make Xdebug work for Linux and WSL2:
+To make Xdebug work:
 
 ```bash
-# Add xdebug to PHP extensions
-ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="xdebug"
-printf "services:\n  frankenphp:\n    extra_hosts:\n      - \"host.docker.internal:host-gateway\"\n" > .ddev/docker-compose.frankenphp_extra.yaml
-ddev stop && ddev debug rebuild -s frankenphp && ddev start
-```
-
----
-
-To make Xdebug work for other setups:
-
-```bash
-ddev start
-printf "services:\n  frankenphp:\n    extra_hosts:\n      - \"host.docker.internal:$(ddev exec "ping -c1 host.docker.internal | awk -F'[()]' '/PING/{print \$2}'")\"\n" > .ddev/docker-compose.frankenphp_extra.yaml
 # Add xdebug to PHP extensions
 ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="xdebug"
 ddev stop && ddev debug rebuild -s frankenphp && ddev start

--- a/config.frankenphp.yaml
+++ b/config.frankenphp.yaml
@@ -1,0 +1,11 @@
+#ddev-generated
+webimage_extra_packages: [socat]
+web_extra_daemons:
+  - name: "frankenphp-socat"
+    command: "socat TCP-LISTEN:80,fork,reuseaddr TCP:frankenphp:80"
+    directory: /var/www/html
+web_extra_exposed_ports:
+  - name: "frankenphp-socat"
+    container_port: 80
+    http_port: 80
+    https_port: 443

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -46,16 +46,9 @@ services:
       - SERVER_NAME=:80
       - SERVER_ROOT=${DDEV_DOCROOT:-.}
       - USER=${DDEV_USER}
-      - VIRTUAL_HOST=${DDEV_HOSTNAME}
-      - HTTP_EXPOSE=80:80
-      - HTTPS_EXPOSE=443:80
-      - PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
     working_dir: /var/www/html
     volumes:
       - "../:/var/www/html"
       - "./php:/usr/local/etc/php/ddev.conf.d"
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
-    # Two lines below are for Xdebug on Linux, see README.md for details
-    # extra_hosts:
-    #   - "host.docker.internal:host-gateway"

--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,7 @@
 name: frankenphp
 
 project_files:
+  - config.frankenphp.yaml
   - commands/frankenphp/php
   - docker-compose.frankenphp.yaml
 


### PR DESCRIPTION
## The Issue

- Fixes #13
- Fixes #25

## How This PR Solves The Issue

After exploring different ways to make FrankenPHP work better with DDEV, I remembered how `socat` was used in https://github.com/atj4me/ddev-tailscale-router (thanks to @atj4me)

Using `socat` here will simplify the setup, and `ddev launch` will work out of the box along with Xdebug.

`ddev describe` will show correct URLs.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev config --webserver-type=generic
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/27/head
ddev restart
ddev describe
ddev launch

ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="xdebug"
ddev restart
# Add a breakpoint in the PHP code and test debugging in PhpStorm
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
