### PR TITLE
feat: add mkcert support, fixes #36

### DIFF
--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -27,3 +27,7 @@ services:
       - "./php:/usr/local/etc/php/ddev.conf.d"
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
+    post_start:
+      - command: mkcert -install
+    external_links:
+      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -4,11 +4,6 @@ FROM ${FRANKENPHP_DOCKER_IMAGE}
 
 SHELL ["/bin/bash", "-eu", "-o", "pipefail", "-c"]
 
-# Install PHP extensions provided by user
-# Always install xdebug, but disable it by default
-ARG FRANKENPHP_PHP_EXTENSIONS=""
-RUN install-php-extensions xdebug ${FRANKENPHP_PHP_EXTENSIONS} && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-
 # Add a new user and give it ownership of frankenphp related files
 ARG username
 ARG uid
@@ -19,6 +14,22 @@ RUN <<EOF
     setcap -r /usr/local/bin/frankenphp
     chown -R ${username}:${username} /data/caddy /config/caddy
 EOF
+
+RUN (apt-get update || true) && apt-get install -y --no-install-recommends sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# CAROOT for `mkcert` to use, has the CA config
+ENV CAROOT=/mnt/ddev-global-cache/mkcert
+# Give the `${username}` user full `sudo` privileges
+RUN mkdir -p /etc/sudoers.d && echo "${username} ALL=(ALL) NOPASSWD: ALL" >> "/etc/sudoers.d/${username}" && chmod 0440 "/etc/sudoers.d/${username}"
+# Install the correct architecture binary of `mkcert`
+ARG TARGETARCH
+RUN mkdir -p /usr/local/bin && curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/${TARGETARCH}" && chmod +x /usr/local/bin/mkcert
+
+# Install PHP extensions provided by user
+# Always install xdebug, but disable it by default
+ARG FRANKENPHP_PHP_EXTENSIONS=""
+RUN install-php-extensions xdebug ${FRANKENPHP_PHP_EXTENSIONS} && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Enable xdebug on demand with custom DDEV config
 ARG FRANKENPHP_XDEBUG=false

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -104,6 +104,14 @@ health_checks() {
     assert_output "FrankenPHP page without worker"
   fi
 
+  run ddev exec -s frankenphp curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  if [[ "${FRANKENPHP_WORKER}" == "true" ]]; then
+    assert_output --partial "FrankenPHP Worker Demo"
+  else
+    assert_output "FrankenPHP page without worker"
+  fi
+
   run curl -sf http://${PROJNAME}.ddev.site
   assert_success
   if [[ "${FRANKENPHP_WORKER}" == "true" ]]; then


### PR DESCRIPTION
## The Issue

- Fixes #36

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Implements technique from https://docs.ddev.com/en/stable/users/extend/custom-compose-files/#third-party-services-may-need-to-trust-ddev-webserver

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
mkdir -p demo && cd demo
ddev config --webserver-type=generic
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/37/head
ddev restart
ddev exec -s frankenphp 'curl https://demo.ddev.site'
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
