### PR TITLE
fix(docker): pull image for offline use

### DIFF
--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -1,7 +1,6 @@
 #ddev-generated
 services:
   web:
-    image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
     build:
       args:
         FRANKENPHP_DEBIAN_CODENAME: ${FRANKENPHP_DEBIAN_CODENAME:-bookworm}
@@ -10,3 +9,8 @@ services:
     environment:
       - SERVER_NAME=:80
       - SERVER_ROOT=${DDEV_DOCROOT:-.}
+  # This service is only used to pull the Docker image for offline use.
+  frankenphp:
+    image: dunglas/frankenphp:php${DDEV_PHP_VERSION}-${FRANKENPHP_DEBIAN_CODENAME:-bookworm}-${DDEV_SITENAME}-built
+    profiles:
+      - frankenphp


### PR DESCRIPTION
## The Issue

If you don't have the `dunglas/frankenphp:phpX.Y-bookworm` image pulled, the add-on isn't going to work offline:

```
$ ddev start
...
 > [web internal] load metadata for docker.io/dunglas/frankenphp:php8.3-bookworm:
------
', stderr='Dockerfile:10

--------------------

   8 |     ARG DDEV_PHP_VERSION

   9 |     ARG FRANKENPHP_DEBIAN_CODENAME=bookworm

  10 | >>> FROM dunglas/frankenphp:php${DDEV_PHP_VERSION}-${FRANKENPHP_DEBIAN_CODENAME} AS frankenphp

  11 |     

  12 |     ### DDEV-injected base Dockerfile contents

--------------------

target web: failed to solve: dunglas/frankenphp:php8.3-bookworm: failed to resolve source metadata for docker.io/dunglas/frankenphp:php8.3-bookworm: failed to do request: Head "https://registry-1.docker.io/v2/dunglas/frankenphp/manifests/php8.3-bookworm": dial tcp: lookup registry-1.docker.io: Temporary failure in name resolution
'
...
```


## How This PR Solves The Issue

Fixes it by adding a dummy optional `frankenphp` service with image, that is going to be pulled on `ddev start`.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/42/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
