### PR TITLE
fix: set permissions for /usr/local/bin

### DIFF
--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -29,7 +29,7 @@ RUN if [ -n "${FRANKENPHP_CUSTOM_EXTENSIONS}" ]; then \
 
 RUN <<EOF
 set -eu -o pipefail
-chmod -fR ugo+w /usr/sbin /usr/bin /usr/local/etc/php
+chmod -fR ugo+w /usr/sbin /usr/bin /usr/local/bin /usr/local/etc/php
 
 cp /etc/php/${DDEV_PHP_VERSION}/fpm/php.ini /usr/local/etc/php/php.ini
 


### PR DESCRIPTION
## The Issue

- https://discord.com/channels/664580571770388500/1454494442215047312

Similar to:
- https://github.com/ddev/ddev-python2/pull/16

## How This PR Solves The Issue

`COPY --from=frankenphp /usr /usr` resets `/usr/local/bin` directory permissions, this PR adds it back.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev config --nodejs-version=18
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/49/head
ddev restart
ddev exec node -v
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
