### PR TITLE
fix: respect assert.ini config, fixes #45

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -58,6 +58,9 @@ health_checks() {
   assert_success
   assert_output --partial "date.timezone => Europe/London"
 
+  run ddev php -r 'assert(false);'
+  assert_failure
+
   run curl -sfI http://${PROJNAME}.ddev.site
   assert_success
   assert_output --partial "HTTP/1.1 200"

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -32,6 +32,7 @@ set -eu -o pipefail
 chmod -fR ugo+w /usr/sbin /usr/bin /usr/local/bin /usr/local/etc/php
 
 cp /etc/php/${DDEV_PHP_VERSION}/fpm/php.ini /usr/local/etc/php/php.ini
+cp /etc/php/${DDEV_PHP_VERSION}/mods-available/assert.ini /usr/local/etc/php/conf.d/assert.ini
 
 rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xhprof.ini
 


### PR DESCRIPTION
## The Issue

- Fixes #45

## How This PR Solves The Issue

Copies `assert.ini` to a proper place.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/50/head
ddev restart
ddev php -r 'assert(false);'
```

Before:

```
$ ddev php -r 'assert(false);'
$ echo $?
0
```

After

```
$ ddev php -r 'assert(false);'
PHP Fatal error:  Uncaught AssertionError: assert(false) in Command line code:1
Stack trace:
#0 Command line code(1): assert()
#1 {main}
  thrown in Command line code on line 1

Fatal error: Uncaught AssertionError: assert(false) in Command line code:1
Stack trace:
#0 Command line code(1): assert()
#1 {main}
  thrown in Command line code on line 1
Failed to run php -r assert(false);: exit status 255
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
