### PR TITLE
feat: switch to phpenmod-zts and phpdismod-zts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 ## Usage
 
-| Command         | Description          |
-|-----------------|----------------------|
-| `ddev describe` | View project status  |
-| `ddev logs -f`  | View FrankenPHP logs |
+| Command                | Description                                           |
+|------------------------|-------------------------------------------------------|
+| `ddev describe`        | View project status                                   |
+| `ddev logs -f`         | View FrankenPHP logs                                  |
+| `ddev utility rebuild` | Get fresh FrankenPHP build inside the `web` container |
 
 ## Advanced Customization
 

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -13,45 +13,18 @@ update-alternatives --install /usr/bin/php php /usr/bin/php-zts 50
 sed -i 's|/usr/bin/php${DDEV_PHP_VERSION}|/usr/bin/php-zts|g' /start.sh
 sed -i 's|/etc/php/${DDEV_PHP_VERSION}/fpm/conf.d/|/etc/php-zts/conf.d/|g' /start.sh
 
-# Patch php-common tools (phpenmod/phpdismod) to work with php-zts paths
-for tool in /usr/lib/php/php-helper /usr/sbin/phpenmod /usr/sbin/phpdismod; do
-    sed -i 's|/etc/php/${version}/${sapi}/conf.d|/etc/php-zts/conf.d|g' "$tool"
-    sed -i 's|/etc/php/${version}/mods-available|/etc/php-zts/mods-available|g' "$tool"
-done
+# Copy DDEV PHP module configurations to php-zts location
+cp /etc/php/${DDEV_PHP_VERSION}/mods-available/assert.ini /etc/php-zts/conf.d/20-assert.ini
+cp /etc/php/${DDEV_PHP_VERSION}/mods-available/blackfire.ini /etc/php-zts/conf.d/90-blackfire.ini
+cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xdebug.ini /etc/php-zts/conf.d/15-xdebug.ini
+cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xhprof.ini /etc/php-zts/conf.d/20-xhprof.ini
 
-# php-zts packages don't provide mods-available structure like standard PHP
-# Migrate numbered conf.d files to mods-available with priority preserved
-mkdir -p /etc/php-zts/mods-available
-for file in /etc/php-zts/conf.d/[0-9]*-*.ini; do
-    [ -f "$file" ] || continue
-    filename=$(basename "$file")
-    priority=$(echo "$filename" | sed 's/^\([0-9]\+\)-.*/\1/')
-    new_name=$(echo "$filename" | sed 's/^[0-9]\+-//')
-    mod_name=$(echo "$new_name" | sed 's/\.ini$//')
-    echo "; priority=${priority}" > "/etc/php-zts/mods-available/${new_name}"
-    cat "$file" >> "/etc/php-zts/mods-available/${new_name}"
-    rm -f "$file"
-    phpenmod "${mod_name}"
-done
+# Create symlinks for phpenmod and phpdismod to use php-zts versions
+ln -sf /usr/sbin/phpenmod-zts /usr/sbin/phpenmod
+ln -sf /usr/sbin/phpdismod-zts /usr/sbin/phpdismod
 
-# Copy DDEV-specific module configs from standard PHP to php-zts
-# Preserve priority from numbered files if they were migrated above
-for mod_file in assert.ini blackfire.ini xdebug.ini xhprof.ini; do
-    source_file="/etc/php/${DDEV_PHP_VERSION}/mods-available/${mod_file}"
-    dest_file="/etc/php-zts/mods-available/${mod_file}"
-    [ -f "$source_file" ] || continue
-    priority_line=""
-    if [ -f "$dest_file" ]; then
-        priority_line=$(head -n 1 "$dest_file" | grep "^; priority=" || true)
-    fi
-    cp "$source_file" "$dest_file"
-    if [ -n "$priority_line" ]; then
-        sed -i "1i${priority_line}" "$dest_file"
-    fi
-done
-
-# Disable xdebug and xhprof by default
-phpdismod xdebug xhprof
+# We don't want these modules enabled by default
+phpdismod assert blackfire xdebug xhprof
 
 # Modify xdebug/xhprof enable/disable scripts to restart via supervisorctl
 # This is needed only for DDEV versions prior to v1.25.0


### PR DESCRIPTION
## The Issue

> Thank you for adding `phpenmod-zts` and `phpdismod-zts`, it's good, but unfortunately it doesn't cover all use cases, for example, [xhprof.ini](https://github.com/ddev/ddev/blob/main/containers/ddev-php-base/ddev-php-files/etc/php/8.5/mods-available/xhprof.ini):
> 
> $ phpdismod-zts xhprof
> $ cat /etc/php-zts/conf.d/20-xhprof.ini 
> ; extension=xhprof.so
> xhprof.output_dir=/tmp/xhprof
> auto_prepend_file=/usr/local/bin/xhprof/xhprof_prepend.php
> `extension` is commented out, but `auto_prepend_file` is not, which results in unwanted behavior.
> 
> Or if there's no extension, we can't control it, [assert.ini](https://github.com/ddev/ddev/blob/main/containers/ddev-php-base/ddev-php-files/etc/php/8.5/mods-available/assert.ini):
> 
> ```
> $ cat /etc/php-zts/conf.d/20-assert.ini
> [Assertion]
> zend.assertions = 1
> ```
> 
> I'm going to keep the existing logic with `mods-available`.

- https://github.com/ddev/ddev-frankenphp/issues/46#issuecomment-3697341149

## How This PR Solves The Issue

Uses `phpenmod-zts` and `phpdismod-zts`

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/53/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
