### PR TITLE
feat: install more PHP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ After installation, make sure to commit the `.ddev` directory to version control
 Install pre-packaged extensions using the `php-zts-` prefix (see [supported extensions](https://pkg.henderkes.com/84/php-zts/packages?type=debian)):
 
 ```bash
-# install sqlsrv and xsl extensions
-ddev config --webimage-extra-packages="php-zts-sqlsrv,php-zts-xsl"
+# install mongodb and sqlsrv extensions
+ddev config --webimage-extra-packages="php-zts-mongodb,php-zts-sqlsrv"
 ddev restart
 ```
 

--- a/config.frankenphp.yaml
+++ b/config.frankenphp.yaml
@@ -16,7 +16,11 @@ webimage_extra_packages:
   - php-zts-bcmath
   - php-zts-bz2
   - php-zts-cli
+  - php-zts-ffi
+  - php-zts-fileinfo
+  - php-zts-ftp
   - php-zts-gd
+  - php-zts-gettext
   - php-zts-imagick
   - php-zts-intl
   - php-zts-ldap
@@ -27,9 +31,14 @@ webimage_extra_packages:
   - php-zts-pdo-sqlite
   - php-zts-pgsql
   - php-zts-redis
+  - php-zts-shmop
   - php-zts-soap
   - php-zts-sqlite3
+  - php-zts-sysvmsg
+  - php-zts-sysvsem
+  - php-zts-sysvshm
   - php-zts-xdebug
   - php-zts-xhprof
+  - php-zts-xsl
   - php-zts-yaml
   - php-zts-zip


### PR DESCRIPTION
## The Issue

I compared `ddev php -m` output for default DDEV setup and FrankenPHP, I missed some extensions.

## How This PR Solves The Issue

Installs more PHP extensions.

The only difference I see: `uploadprogress` and `xmlrpc` are missing in https://pkg.henderkes.com/84/php-zts/packages?type=debian

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/56/head
ddev restart
ddev php -m
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
