### PR TITLE
fix: remove php-zts-fileinfo, improve tests, fixes #58

### DIFF
--- a/config.frankenphp.yaml
+++ b/config.frankenphp.yaml
@@ -17,7 +17,6 @@ webimage_extra_packages:
   - php-zts-bz2
   - php-zts-cli
   - php-zts-ffi
-  - php-zts-fileinfo
   - php-zts-ftp
   - php-zts-gd
   - php-zts-gettext

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -50,6 +50,8 @@ health_checks() {
   run ddev php -v
   assert_success
   assert_output --partial "PHP ${FRANKENPHP_PHP_VERSION}"
+  refute_output --partial "Warning"
+  refute_output --partial "is already loaded"
 
   run ddev php --ini
   assert_success
@@ -134,9 +136,32 @@ health_checks() {
 
   run ddev php -m
   assert_success
-  assert_output --partial "pdo_mysql"
-  assert_output --partial "pdo_pgsql"
-  assert_output --partial "zip"
+  assert_line "apcu"
+  assert_line "bcmath"
+  assert_line "bz2"
+  assert_line "FFI"
+  assert_line "fileinfo"
+  assert_line "ftp"
+  assert_line "gd"
+  assert_line "gettext"
+  assert_line "imagick"
+  assert_line "intl"
+  assert_line "ldap"
+  assert_line "memcached"
+  assert_line "mysqli"
+  assert_line "pdo_mysql"
+  assert_line "pdo_pgsql"
+  assert_line "pgsql"
+  assert_line "redis"
+  assert_line "shmop"
+  assert_line "soap"
+  assert_line "sqlite3"
+  assert_line "sysvmsg"
+  assert_line "sysvsem"
+  assert_line "sysvshm"
+  assert_line "xsl"
+  assert_line "yaml"
+  assert_line "zip"
 
   if [[ "${FRANKENPHP_CUSTOM_EXTENSION}" == "true" ]]; then
     assert_output --partial "example_pie_extension"


### PR DESCRIPTION
## The Issue

- Fixes #58

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Removes `php-zts-fileinfo`.
- Adds explicit check in tests for all installed extra extensions.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/59/head
ddev restart
ddev php -v # no warning here
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
