### PR TITLE
fix(extensions): make xdebug and xhprof work, add better test coverage, fixes #61

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -52,6 +52,8 @@ health_checks() {
   assert_output --partial "PHP ${FRANKENPHP_PHP_VERSION}"
   refute_output --partial "Warning"
   refute_output --partial "is already loaded"
+  refute_output --partial "cannot open shared object file"
+  refute_output --partial "in Unknown on line"
 
   run ddev php --ini
   assert_success
@@ -164,31 +166,28 @@ health_checks() {
   assert_line "zip"
 
   if [[ "${FRANKENPHP_CUSTOM_EXTENSION}" == "true" ]]; then
-    assert_output --partial "example_pie_extension"
+    assert_line "example_pie_extension"
   else
-    refute_output --partial "example_pie_extension"
+    refute_line "example_pie_extension"
   fi
 
-  run ddev xdebug on
-  assert_success
+  refute_output --partial "Warning"
+  refute_output --partial "is already loaded"
+  refute_output --partial "cannot open shared object file"
+  refute_output --partial "in Unknown on line"
 
-  run ddev php -m
-  assert_success
-  assert_output --partial "xdebug"
+  for extension in xdebug xhprof blackfire; do
+    run ddev "${extension}" on
+    assert_success
 
-  run ddev xhprof on
-  assert_success
-
-  run ddev php -m
-  assert_success
-  assert_output --partial "xhprof"
-
-  run ddev blackfire on
-  assert_success
-
-  run ddev php -m
-  assert_success
-  assert_output --partial "blackfire"
+    run ddev php -m
+    assert_success
+    assert_line "${extension}"
+    refute_output --partial "Warning"
+    refute_output --partial "is already loaded"
+    refute_output --partial "cannot open shared object file"
+    refute_output --partial "in Unknown on line"
+  done
 }
 
 teardown() {

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -17,8 +17,26 @@ sed -i 's|/etc/php/${DDEV_PHP_VERSION}/fpm/conf.d/|/etc/php-zts/conf.d/|g' /star
 # Copy DDEV PHP module configurations to php-zts location
 cp /etc/php/${DDEV_PHP_VERSION}/mods-available/assert.ini /etc/php-zts/conf.d/20-assert.ini
 cp /etc/php/${DDEV_PHP_VERSION}/mods-available/blackfire.ini /etc/php-zts/conf.d/90-blackfire.ini
-cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xdebug.ini /etc/php-zts/conf.d/15-xdebug.ini
-cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xhprof.ini /etc/php-zts/conf.d/20-xhprof.ini
+
+# Append DDEV extension configurations to existing php-zts ini files
+for EXT_NAME in xdebug xhprof; do
+    # Find the source extension ini file in mods-available
+    EXT_SRC_INI=$(find "/etc/php/${DDEV_PHP_VERSION}/mods-available" -name "*${EXT_NAME}*.ini" -type f | head -n 1)
+    if [ -z "$EXT_SRC_INI" ]; then
+        echo "ERROR: ${EXT_NAME} ini file not found in /etc/php/${DDEV_PHP_VERSION}/mods-available" >&2
+        exit 1
+    fi
+
+    # Find the destination extension ini file in php-zts conf.d
+    EXT_ZTS_INI=$(find /etc/php-zts/conf.d -name "*${EXT_NAME}*.ini" -type f | head -n 1)
+    if [ -z "$EXT_ZTS_INI" ]; then
+        echo "ERROR: ${EXT_NAME} ini file not found in /etc/php-zts/conf.d" >&2
+        exit 1
+    fi
+
+    # Append config from mods-available, excluding extension loading lines
+    grep -v -E '^(zend_)?extension=' "$EXT_SRC_INI" >> "$EXT_ZTS_INI"
+done
 
 # Create symlinks for phpenmod and phpdismod to use php-zts versions
 ln -sf /usr/sbin/phpenmod-zts /usr/sbin/phpenmod

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -20,6 +20,11 @@ cp /etc/php/${DDEV_PHP_VERSION}/mods-available/blackfire.ini /etc/php-zts/conf.d
 cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xdebug.ini /etc/php-zts/conf.d/15-xdebug.ini
 cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xhprof.ini /etc/php-zts/conf.d/20-xhprof.ini
 
+# Fix extension .so paths for php-zts (they use versioned names like xdebug-zts-84)
+PHP_ZTS_VERSION=$(echo $DDEV_PHP_VERSION | tr -d '.')
+sed -i "s|zend_extension=xdebug.so|zend_extension=xdebug-zts-${PHP_ZTS_VERSION}|" /etc/php-zts/conf.d/15-xdebug.ini
+sed -i "s|extension=xhprof.so|extension=xhprof-zts-${PHP_ZTS_VERSION}|" /etc/php-zts/conf.d/20-xhprof.ini
+
 # Create symlinks for phpenmod and phpdismod to use php-zts versions
 ln -sf /usr/sbin/phpenmod-zts /usr/sbin/phpenmod
 ln -sf /usr/sbin/phpdismod-zts /usr/sbin/phpdismod

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -20,11 +20,6 @@ cp /etc/php/${DDEV_PHP_VERSION}/mods-available/blackfire.ini /etc/php-zts/conf.d
 cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xdebug.ini /etc/php-zts/conf.d/15-xdebug.ini
 cp /etc/php/${DDEV_PHP_VERSION}/mods-available/xhprof.ini /etc/php-zts/conf.d/20-xhprof.ini
 
-# Fix extension .so paths for php-zts (they use versioned names like xdebug-zts-84)
-PHP_ZTS_VERSION=$(echo $DDEV_PHP_VERSION | tr -d '.')
-sed -i "s|zend_extension=xdebug.so|zend_extension=xdebug-zts-${PHP_ZTS_VERSION}|" /etc/php-zts/conf.d/15-xdebug.ini
-sed -i "s|extension=xhprof.so|extension=xhprof-zts-${PHP_ZTS_VERSION}|" /etc/php-zts/conf.d/20-xhprof.ini
-
 # Create symlinks for phpenmod and phpdismod to use php-zts versions
 ln -sf /usr/sbin/phpenmod-zts /usr/sbin/phpenmod
 ln -sf /usr/sbin/phpdismod-zts /usr/sbin/phpdismod

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -44,6 +44,8 @@ ln -sf /usr/sbin/phpdismod-zts /usr/sbin/phpdismod
 
 # Reconfigure blackfire-php if installed, to match the current PHP version
 if dpkg -s blackfire-php >/dev/null 2>&1; then
+    apt-get update || true
+    apt-get install -y --only-upgrade blackfire-php
     dpkg-reconfigure blackfire-php
 fi
 


### PR DESCRIPTION
## The Issue

- Fixes #61

## How This PR Solves The Issue

Updates configuration to append `xdebug.ini` and `xhprof.ini` config dynamically without hardcoding.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/62/head
ddev restart
ddev xdebug on
ddev php -m # no warning here
ddev xhprof on
ddev php -m # no warning here
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
