### PR TITLE
fix: link versioned php command to php-zts, fixes #65

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -56,14 +56,9 @@ health_checks() {
   refute_output --partial "cannot open shared object file"
   refute_output --partial "in Unknown on line"
 
-  run ddev exec "php${FRANKENPHP_PHP_VERSION}" -v
+  run ddev exec "readlink /usr/bin/php${FRANKENPHP_PHP_VERSION}"
   assert_success
-  assert_output --partial "PHP ${FRANKENPHP_PHP_VERSION}"
-  assert_output --partial "ZTS"
-  refute_output --partial "Warning"
-  refute_output --partial "is already loaded"
-  refute_output --partial "cannot open shared object file"
-  refute_output --partial "in Unknown on line"
+  assert_output "/usr/bin/php"
 
   run ddev php --ini
   assert_success

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -50,6 +50,16 @@ health_checks() {
   run ddev php -v
   assert_success
   assert_output --partial "PHP ${FRANKENPHP_PHP_VERSION}"
+  assert_output --partial "ZTS"
+  refute_output --partial "Warning"
+  refute_output --partial "is already loaded"
+  refute_output --partial "cannot open shared object file"
+  refute_output --partial "in Unknown on line"
+
+  run ddev exec "php${FRANKENPHP_PHP_VERSION}" -v
+  assert_success
+  assert_output --partial "PHP ${FRANKENPHP_PHP_VERSION}"
+  assert_output --partial "ZTS"
   refute_output --partial "Warning"
   refute_output --partial "is already loaded"
   refute_output --partial "cannot open shared object file"

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -9,7 +9,8 @@ set -eu -o pipefail
 cp /etc/php/${DDEV_PHP_VERSION}/fpm/php.ini /etc/php-zts/php.ini
 update-alternatives --install /usr/bin/php php /usr/bin/php-zts 50
 update-alternatives --set php /usr/bin/php-zts
-ln -sf /usr/bin/php-zts /usr/bin/php${DDEV_PHP_VERSION}
+# Update the versioned php binary to point to php-zts
+ln -sf /usr/bin/php /usr/bin/php${DDEV_PHP_VERSION}
 
 # Patch start.sh to use php-zts paths
 sed -i 's|/usr/bin/php${DDEV_PHP_VERSION}|/usr/bin/php-zts|g' /start.sh

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -9,6 +9,7 @@ set -eu -o pipefail
 cp /etc/php/${DDEV_PHP_VERSION}/fpm/php.ini /etc/php-zts/php.ini
 update-alternatives --install /usr/bin/php php /usr/bin/php-zts 50
 update-alternatives --set php /usr/bin/php-zts
+ln -sf /usr/bin/php-zts /usr/bin/php${DDEV_PHP_VERSION}
 
 # Patch start.sh to use php-zts paths
 sed -i 's|/usr/bin/php${DDEV_PHP_VERSION}|/usr/bin/php-zts|g' /start.sh


### PR DESCRIPTION
## The Issue

- Fixes #65

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Adds a symlink, updates tests.

## Manual Testing Instructions

```bash
ddev config --php-version=8.5
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/67/head
ddev restart
ddev php -v
ddev exec php8.5 -v
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
