### PR TITLE
fix(php): add writetable session, fixes #66

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -40,6 +40,9 @@ setup() {
   cp "${DIR}"/tests/testdata/.ddev/php/php.ini .ddev/php/php.ini
   assert_file_exist .ddev/php/php.ini
 
+  cp "${DIR}"/tests/testdata/session-test.php session-test.php
+  assert_file_exist session-test.php
+
   export FRANKENPHP_PHP_VERSION=8.4
   export FRANKENPHP_WORKER=false
   export FRANKENPHP_CUSTOM_EXTENSION=false
@@ -71,6 +74,12 @@ health_checks() {
 
   run ddev php -r 'assert(false);'
   assert_failure
+
+  run ddev php /var/www/html/session-test.php
+  assert_success
+  assert_output --partial "SESSION_OK"
+  assert_output --partial "/var/lib/php-zts/session"
+  refute_output --partial "Permission denied"
 
   run curl -sfI http://${PROJNAME}.ddev.site
   assert_success

--- a/tests/testdata/session-test.php
+++ b/tests/testdata/session-test.php
@@ -1,0 +1,22 @@
+<?php
+
+$id = 'frankenphpsessiontest';
+session_id($id);
+if (!session_start()) {
+    fwrite(STDERR, "session_start() failed\n");
+    exit(1);
+}
+$_SESSION['probe'] = 'frankenphp-session-ok';
+session_write_close();
+$path = session_save_path();
+$file = $path . '/sess_' . $id;
+if (!is_file($file)) {
+    fwrite(STDERR, "session file not created at $file\n");
+    exit(1);
+}
+if (strpos((string)file_get_contents($file), 'frankenphp-session-ok') === false) {
+    fwrite(STDERR, "session payload missing from $file\n");
+    exit(1);
+}
+@unlink($file);
+echo "SESSION_OK save_path=$path\n";

--- a/web-build/Dockerfile.frankenphp
+++ b/web-build/Dockerfile.frankenphp
@@ -69,5 +69,5 @@ for script_file in "${scripts[@]}"; do
 done
 
 # Ensure write permissions for all users on php-zts directories
-chmod -fR ugo+w /etc/php-zts /var/lib/php-zts
+chmod -fR ugo+rwX /etc/php-zts /var/lib/php-zts
 EOF


### PR DESCRIPTION
## The Issue

- Fixes #66

## How This PR Solves The Issue

Adjusts directory permissions for `/var/lib/php-zts`.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-frankenphp/tarball/refs/pull/68/head
ddev restart
```

## Automated Testing Overview

Covered by a new test.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
